### PR TITLE
Add SDK CLI npm bugs metadata

### DIFF
--- a/packages/sdk-cli/package.json
+++ b/packages/sdk-cli/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/sisense/compose-sdk-monorepo",
     "directory": "packages/sdk-cli"
   },
+  "bugs": {
+    "url": "https://github.com/sisense/compose-sdk-monorepo/issues"
+  },
   "keywords": [
     "Sisense",
     "Compose SDK"


### PR DESCRIPTION
## Summary

Add standard npm `bugs` metadata to `packages/sdk-cli/package.json`.

The published `@sisense/sdk-cli@2.28.0` package already exposes `homepage` and monorepo `repository` metadata, but `npm view @sisense/sdk-cli@2.28.0 name version homepage repository bugs --json` does not return a `bugs` field. This change points package consumers to the existing public issue tracker.

## Validation

- `npm view @sisense/sdk-cli@2.28.0 name version homepage repository bugs --json`
- `node -e "const p=require('./packages/sdk-cli/package.json'); if(!p.bugs?.url?.includes('sisense/compose-sdk-monorepo/issues')) throw new Error('bugs metadata mismatch'); console.log(JSON.stringify({name:p.name,homepage:p.homepage,repository:p.repository,bugs:p.bugs}, null, 2));"`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts` from `packages/sdk-cli`

## Scope

Manifest metadata only. No runtime code, dependency, or lockfile changes.
